### PR TITLE
Video frames bug

### DIFF
--- a/Team8-Fundus-Photography/Team8-Fundus-Photography.xcodeproj/project.pbxproj
+++ b/Team8-Fundus-Photography/Team8-Fundus-Photography.xcodeproj/project.pbxproj
@@ -500,7 +500,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Team8-Fundus-Photography/Preview Content\"";
-				DEVELOPMENT_TEAM = K4BVXF6729;
+				DEVELOPMENT_TEAM = T44S569Z79;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Team8-Fundus-Photography/Info.plist";
@@ -536,7 +536,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Team8-Fundus-Photography/Preview Content\"";
-				DEVELOPMENT_TEAM = K4BVXF6729;
+				DEVELOPMENT_TEAM = T44S569Z79;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Team8-Fundus-Photography/Info.plist";

--- a/Team8-Fundus-Photography/Team8-Fundus-Photography/Controller/FirebaseManager.swift
+++ b/Team8-Fundus-Photography/Team8-Fundus-Photography/Controller/FirebaseManager.swift
@@ -271,7 +271,64 @@ class FirebaseManager: ObservableObject {
         }
     }
     
-    
+    func fetchImagesByPosition(patientID: String, scanID: String, position: String, completion: @escaping () -> Void) {
+        print("Fetching images for position: \(position)")
+
+        let db = Firestore.firestore()
+        let imagesRef = db.collection("images")
+        let dispatchGroup = DispatchGroup()
+
+        var fetchedImages: [LabeledImage] = []
+
+        imagesRef.whereField("patientID", isEqualTo: patientID)
+            .whereField("scanID", isEqualTo: scanID)
+            .whereField("position", isEqualTo: position)
+            .getDocuments { (snapshot, error) in
+                if let error = error {
+                    print("Error fetching images for \(position): \(error.localizedDescription)")
+                    completion()
+                    return
+                }
+
+                guard let snapshot = snapshot, !snapshot.isEmpty else {
+                    print("No images found for \(position)")
+                    self.imagesByPosition[position] = []
+                    completion()
+                    return
+                }
+
+                for document in snapshot.documents {
+                    let data = document.data()
+
+                    guard let imageURLString = data["url"] as? String,
+                          let isPrimary = data["isPrimary"] as? Bool else {
+                        print("Skipping document \(document.documentID) due to missing fields")
+                        continue
+                    }
+
+                    let comment = data["comment"] as? String ?? ""
+                    let imageID = document.documentID
+
+                    dispatchGroup.enter()
+
+                    self.downloadImage(from: imageURLString, position: position) { image in
+                        if let image = image {
+                            let labeledImage = LabeledImage(id: imageID, isPrimary: isPrimary, position: position, image: image, comment: comment)
+                            fetchedImages.append(labeledImage)
+                        }
+                        dispatchGroup.leave()
+                    }
+                }
+
+                dispatchGroup.notify(queue: .main) {
+                    self.imagesByPosition[position] = fetchedImages
+                    print("Fetched \(fetchedImages.count) images for \(position)")
+                    completion()
+                }
+            }
+    }
+
+
     
     func fetchPrimaryLabeledImages(patientID: String, scanID: String, completion: @escaping ([LabeledImage]) -> Void) {
         let db = Firestore.firestore()

--- a/Team8-Fundus-Photography/Team8-Fundus-Photography/View/VideoFrameSelectorView.swift
+++ b/Team8-Fundus-Photography/Team8-Fundus-Photography/View/VideoFrameSelectorView.swift
@@ -42,7 +42,10 @@ struct VideoFrameSelectorView: View {
             
             actionButtonsSection
         }
-        .onAppear { loadVideo() }
+        .onAppear {
+            loadVideo()
+            fetchImagesByPosition()
+        }
         .onChange(of: currentTime) { newTime in
             sliderValue = CMTimeGetSeconds(newTime)
         }
@@ -66,6 +69,18 @@ struct VideoFrameSelectorView: View {
         }
     }
     
+    private func fetchImagesByPosition() {
+        let currentPosition = selectedDataManager.getQuadrant().rawValue
+        let patientID = selectedDataManager.getPatientID()
+        let scanID = selectedDataManager.getScanID()
+
+        firebaseManager.fetchImagesByPosition(patientID: patientID, scanID: scanID, position: currentPosition) {
+            DispatchQueue.main.async {
+                print("Fetched images for position: \(currentPosition)")
+            }
+        }
+    }
+
     // Video Player Section
     private var videoPlayerSection: some View {
         Group {
@@ -277,6 +292,7 @@ struct VideoFrameSelectorView: View {
             }
         }
     }
+    
 }
 
 #Preview {


### PR DESCRIPTION
fixed video bug: images from other scans showing on the images displayed in video captured.
Reason: we were directly using imagesbyposition array (race condition)
Solution: fetch images by position on db whenever vide frame view appears to renew the list every time. 